### PR TITLE
Feat: 단일 문서의 단어 개수 저장 기능 구현

### DIFF
--- a/.idea/modules/keyword-analyzer.iml
+++ b/.idea/modules/keyword-analyzer.iml
@@ -5,4 +5,7 @@
       <excludeFolder url="file://$MODULE_DIR$/../../keyword-analyzer/.idea" />
     </content>
   </component>
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
 </module>

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/EntityNotFoundException.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/EntityNotFoundException.java
@@ -1,7 +1,7 @@
 package com.example.keywordanalyzer.exception;
 
 public class EntityNotFoundException extends RuntimeException {
-	public EntityNotFoundException(String entityName, Long Id) {
-		super(entityName + " not found. " + entityName + " Id : " + Id);
+	public EntityNotFoundException(String entityName, Long id) {
+		super(entityName + " not found. " + entityName + " Id : " + id);
 	}
 }

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/EntityNotFoundException.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.keywordanalyzer.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+	public EntityNotFoundException(String entityName, Long Id) {
+		super(entityName + " not found. " + entityName + " Id : " + Id);
+	}
+}

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/WordCollectionNotFoundException.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/exception/WordCollectionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.keywordanalyzer.exception;
+
+public class WordCollectionNotFoundException extends EntityNotFoundException {
+	public WordCollectionNotFoundException(Long wordCollectionId) {
+		super("WordCollection", wordCollectionId);
+	}
+}

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/model/entity/Post.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/model/entity/Post.java
@@ -32,6 +32,14 @@ public class Post {
 	protected Post() {
 	}
 
+	public Post(Long id, String content, LocalDateTime createdAt, Long collectionId, Long apiId) {
+		this.id = id;
+		this.content = content;
+		this.createdAt = createdAt;
+		this.collectionId = collectionId;
+		this.apiId = apiId;
+	}
+
 	public Post(String content, LocalDateTime createdAt, Long collectionId, Long apiId) {
 		this.content = content;
 		this.createdAt = createdAt;

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/DocumentCountRepository.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/DocumentCountRepository.java
@@ -1,5 +1,7 @@
 package com.example.keywordanalyzer.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.example.keywordanalyzer.model.entity.DocumentCount;
 
 @Repository
 public interface DocumentCountRepository extends JpaRepository<DocumentCount, Long> {
+	Optional<DocumentCount> findByCollectionId(Long wordCollectionId);
 }

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/DocumentCountRepository.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/DocumentCountRepository.java
@@ -9,5 +9,5 @@ import com.example.keywordanalyzer.model.entity.DocumentCount;
 
 @Repository
 public interface DocumentCountRepository extends JpaRepository<DocumentCount, Long> {
-	Optional<DocumentCount> findByCollectionId(Long wordCollectionId);
+	Optional<DocumentCount> findByCollectionIdAndTerm(Long wordCollectionId, String term);
 }

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/TermCountRepository.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/repository/TermCountRepository.java
@@ -1,5 +1,7 @@
 package com.example.keywordanalyzer.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.example.keywordanalyzer.model.entity.TermCount;
 
 @Repository
 public interface TermCountRepository extends JpaRepository<TermCount, Long> {
+	Optional<TermCount> findByPostIdAndTerm(long postId, String term);
 }

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/DocumentCountService.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/DocumentCountService.java
@@ -1,0 +1,22 @@
+package com.example.keywordanalyzer.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.keywordanalyzer.model.entity.DocumentCount;
+import com.example.keywordanalyzer.repository.DocumentCountRepository;
+
+@Service
+public class DocumentCountService {
+	private final DocumentCountRepository documentCountRepository;
+
+	public DocumentCountService(DocumentCountRepository documentCountRepository) {
+		this.documentCountRepository = documentCountRepository;
+	}
+
+	public void updateDocumentCount(DocumentCount documentCount) {
+		if (documentCount.getDocumentCount() < 0) {
+			throw new IllegalArgumentException("Document count cannot be negative");
+		}
+		documentCountRepository.save(documentCount);
+	}
+}

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
@@ -31,16 +31,19 @@ public class TermCountService {
 	public void saveTermCount(Post post) {
 		HashMap<String, Integer> termCountMap = NlpUtil.extractNoun(post.getContent());
 		Long wordCollectionId = post.getCollectionId();
+		Long postId = post.getId();
 
 		if (!wordCollectionRepository.existsById(wordCollectionId)) {
 			throw new NoSuchElementException("WordCollection not found. WordCollection Id : " + wordCollectionId);
 		}
 
 		termCountMap.forEach((term, count) -> {
-			TermCount termCount = new TermCount(term, count, post.getId());
+			TermCount termCount = termCountRepository.findByPostIdAndTerm(postId, term)
+				.orElse(new TermCount(term, 0, postId));
+			termCount.setTermCount(termCount.getTermCount() + count);
 			termCountRepository.save(termCount);
 
-			DocumentCount documentCount = documentCountRepository.findByCollectionId(wordCollectionId)
+			DocumentCount documentCount = documentCountRepository.findByCollectionIdAndTerm(wordCollectionId, term)
 				.orElse(new DocumentCount(term, 0, wordCollectionId));
 			documentCount.setDocumentCount(documentCount.getDocumentCount() + count);
 			documentCountRepository.save(documentCount);

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
@@ -1,0 +1,49 @@
+package com.example.keywordanalyzer.service;
+
+import java.util.HashMap;
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.keywordanalyzer.model.entity.DocumentCount;
+import com.example.keywordanalyzer.model.entity.Post;
+import com.example.keywordanalyzer.model.entity.TermCount;
+import com.example.keywordanalyzer.repository.DocumentCountRepository;
+import com.example.keywordanalyzer.repository.TermCountRepository;
+import com.example.keywordanalyzer.repository.WordCollectionRepository;
+import com.example.keywordanalyzer.util.NlpUtil;
+
+@Service
+public class TermCountService {
+	private final TermCountRepository termCountRepository;
+	private final WordCollectionRepository wordCollectionRepository;
+	private final DocumentCountRepository documentCountRepository;
+
+	public TermCountService(TermCountRepository repository, WordCollectionRepository wordCollectionRepository,
+		DocumentCountRepository documentCountRepository) {
+		this.termCountRepository = repository;
+		this.documentCountRepository = documentCountRepository;
+		this.wordCollectionRepository = wordCollectionRepository;
+	}
+
+	@Transactional
+	public void saveTermCount(Post post) {
+		HashMap<String, Integer> termCountMap = NlpUtil.extractNoun(post.getContent());
+		Long wordCollectionId = post.getCollectionId();
+
+		if (!wordCollectionRepository.existsById(wordCollectionId)) {
+			throw new NoSuchElementException("WordCollection not found. WordCollection Id : " + wordCollectionId);
+		}
+
+		termCountMap.forEach((term, count) -> {
+			TermCount termCount = new TermCount(term, count, post.getId());
+			termCountRepository.save(termCount);
+
+			DocumentCount documentCount = documentCountRepository.findByCollectionId(wordCollectionId)
+				.orElse(new DocumentCount(term, 0, wordCollectionId));
+			documentCount.setDocumentCount(documentCount.getDocumentCount() + count);
+			documentCountRepository.save(documentCount);
+		});
+	}
+}

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
@@ -1,11 +1,11 @@
 package com.example.keywordanalyzer.service;
 
 import java.util.HashMap;
-import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.keywordanalyzer.exception.WordCollectionNotFoundException;
 import com.example.keywordanalyzer.model.entity.DocumentCount;
 import com.example.keywordanalyzer.model.entity.Post;
 import com.example.keywordanalyzer.model.entity.TermCount;
@@ -34,7 +34,7 @@ public class TermCountService {
 		Long postId = post.getId();
 
 		if (!wordCollectionRepository.existsById(wordCollectionId)) {
-			throw new NoSuchElementException("WordCollection not found. WordCollection Id : " + wordCollectionId);
+			throw new WordCollectionNotFoundException(wordCollectionId);
 		}
 
 		termCountMap.forEach((term, count) -> {

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/service/TermCountService.java
@@ -27,6 +27,20 @@ public class TermCountService {
 		this.wordCollectionRepository = wordCollectionRepository;
 	}
 
+	private void updateTermCount(Long postId, String term, int count) {
+		TermCount termCount = termCountRepository.findByPostIdAndTerm(postId, term)
+			.orElse(new TermCount(term, 0, postId));
+		termCount.setTermCount(termCount.getTermCount() + count);
+		termCountRepository.save(termCount);
+	}
+
+	private void updateDocumentCount(Long wordCollectionId, String term, int count) {
+		DocumentCount documentCount = documentCountRepository.findByCollectionIdAndTerm(wordCollectionId, term)
+			.orElse(new DocumentCount(term, 0, wordCollectionId));
+		documentCount.setDocumentCount(documentCount.getDocumentCount() + count);
+		documentCountRepository.save(documentCount);
+	}
+
 	@Transactional
 	public void saveTermCount(Post post) {
 		HashMap<String, Integer> termCountMap = NlpUtil.extractNoun(post.getContent());
@@ -38,15 +52,9 @@ public class TermCountService {
 		}
 
 		termCountMap.forEach((term, count) -> {
-			TermCount termCount = termCountRepository.findByPostIdAndTerm(postId, term)
-				.orElse(new TermCount(term, 0, postId));
-			termCount.setTermCount(termCount.getTermCount() + count);
-			termCountRepository.save(termCount);
-
-			DocumentCount documentCount = documentCountRepository.findByCollectionIdAndTerm(wordCollectionId, term)
-				.orElse(new DocumentCount(term, 0, wordCollectionId));
-			documentCount.setDocumentCount(documentCount.getDocumentCount() + count);
-			documentCountRepository.save(documentCount);
+			updateTermCount(postId, term, count);
+			updateDocumentCount(wordCollectionId, term, count);
 		});
 	}
+
 }

--- a/keyword-analyzer/src/main/java/com/example/keywordanalyzer/util/TestUtil.java
+++ b/keyword-analyzer/src/main/java/com/example/keywordanalyzer/util/TestUtil.java
@@ -1,0 +1,26 @@
+package com.example.keywordanalyzer.util;
+
+import java.util.Map;
+
+public class TestUtil {
+	public static <K, V> boolean assertMapEquals(Map<K, V> expected, Map<K, V> actual) {
+		if (expected.size() != actual.size()) {
+			return false;
+		}
+
+		for (Map.Entry<K, V> entry : expected.entrySet()) {
+			K key = entry.getKey();
+			V value = entry.getValue();
+
+			if (!actual.containsKey(key)) {
+				return false;
+			}
+
+			if (!value.equals(actual.get(key))) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/keyword-analyzer/src/test/java/com/example/keywordanalyzer/learning/MockitoTest.java
+++ b/keyword-analyzer/src/test/java/com/example/keywordanalyzer/learning/MockitoTest.java
@@ -1,0 +1,40 @@
+package com.example.keywordanalyzer.learning;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MockitoTest {
+	@Mock
+	List<String> testMockString;
+
+	@Test
+	void testBasicMockito() {
+		// Mock 객체 생성
+		List<?> mockList = Mockito.mock(List.class);
+
+		// Mock 객체의 동작 정의
+		Mockito.when(mockList.size()).thenReturn(5);
+
+		// Mock 객체 사용
+		int size = mockList.size(); // 5를 반환
+		assertEquals(5, size);
+	}
+
+	@Test
+	void testMockAnnotation() {
+		// Mock 동작 정의
+		Mockito.when(testMockString.size()).thenReturn(5);
+
+		// Mock 객체 사용
+		int size = testMockString.size();
+		assertEquals(5, size);
+	}
+}

--- a/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/DocumentCountServiceTest.java
+++ b/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/DocumentCountServiceTest.java
@@ -1,0 +1,47 @@
+package com.example.keywordanalyzer.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.keywordanalyzer.model.entity.DocumentCount;
+import com.example.keywordanalyzer.repository.DocumentCountRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class DocumentCountServiceTest {
+	@Mock
+	private DocumentCountRepository documentCountRepository;
+
+	@InjectMocks
+	private DocumentCountService documentCountService;
+
+	@Test
+	void updateDocumentCountSuccess() {
+		// Arrange
+		DocumentCount documentCount = new DocumentCount("test", 5, 1L);
+
+		// Act
+		int count = documentCount.getDocumentCount();
+		documentCount.setDocumentCount(count + 1);
+		documentCountService.updateDocumentCount(documentCount);
+
+		// Assert
+		verify(documentCountRepository, times(1)).save(documentCount);
+		assertEquals(6, documentCount.getDocumentCount());
+	}
+
+	@Test
+	void updateDocumentCountWrongInputFormat() {
+		// Arrange
+		DocumentCount documentCount = new DocumentCount("test", -1, 1L);
+
+		// Act, Assert
+		assertThrows(IllegalArgumentException.class,
+			() -> documentCountService.updateDocumentCount(documentCount));
+	}
+}

--- a/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceIntegrationTest.java
+++ b/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceIntegrationTest.java
@@ -1,0 +1,72 @@
+package com.example.keywordanalyzer.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.keywordanalyzer.model.entity.DocumentCount;
+import com.example.keywordanalyzer.model.entity.Post;
+import com.example.keywordanalyzer.model.entity.TermCount;
+import com.example.keywordanalyzer.repository.DocumentCountRepository;
+import com.example.keywordanalyzer.repository.TermCountRepository;
+
+@SpringBootTest
+@Transactional
+public class TermCountServiceIntegrationTest {
+	private final TermCountRepository termCountRepository;
+	private final DocumentCountRepository documentCountRepository;
+	private final TermCountService service;
+
+	@Autowired
+	public TermCountServiceIntegrationTest(TermCountRepository termCountRepository,
+		DocumentCountRepository documentCountRepository,
+		TermCountService service) {
+		this.termCountRepository = termCountRepository;
+		this.documentCountRepository = documentCountRepository;
+		this.service = service;
+	}
+
+	@Test
+	void saveTermCountWithSinglePost() {
+		// Arrange
+		long collectionId = 1L;
+		long postId = 1L;
+		Post post = new Post(postId, "Hello World! This test is post test.", LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+			collectionId, 1L);
+
+		// Act
+		service.saveTermCount(post);
+
+		// Assert
+		HashMap<String, Integer> termCountTuples = new HashMap<>();
+		termCountTuples.put("World", 1);
+		termCountTuples.put("test", 2);
+		termCountTuples.put("post", 1);
+
+		for (String term : termCountTuples.keySet()) {
+			// TermCount 생성 확인
+			Optional<TermCount> termCountOptional = termCountRepository.findByPostIdAndTerm(postId, term);
+			assertTrue(termCountOptional.isPresent());
+			TermCount termCount = termCountOptional.orElseThrow();
+			int expectedTermCount = termCountTuples.get(term);
+			int actualTermCount = termCount.getTermCount();
+			assertEquals(expectedTermCount, actualTermCount);
+
+			// DocumentCount 업데이트 확인
+			Optional<DocumentCount> documentCountOptional = documentCountRepository.findByCollectionIdAndTerm(
+				collectionId, term);
+			assertTrue(documentCountOptional.isPresent());
+			DocumentCount documentCount = documentCountOptional.orElseThrow();
+			int actualDocumentCount = documentCount.getDocumentCount();
+			assertEquals(expectedTermCount, actualDocumentCount);
+		}
+
+	}
+}

--- a/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceTest.java
+++ b/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceTest.java
@@ -3,9 +3,7 @@ package com.example.keywordanalyzer.service;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,19 +37,17 @@ public class TermCountServiceTest {
 	@InjectMocks
 	private TermCountService service;
 
-	private Post post;
-
 	@BeforeEach
 	void setUp() {
 		Mockito.when(wordCollection.getId()).thenReturn(1L);
 		Mockito.when(wordCollectionRepository.existsById(wordCollection.getId())).thenReturn(true);
-		post = new Post("Hello World! This is test post.", LocalDateTime.of(2024, 1, 1, 0, 0, 0),
-			wordCollection.getId(), 1L);
 	}
 
 	@Test
-	void saveTermCountWithPost() {
+	void saveTermCountWithSinglePost() {
 		// Arrange
+		Post post = new Post(1L, "Hello World! This test is test post.", LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+			wordCollection.getId(), 1L);
 
 		// Act
 		service.saveTermCount(post);
@@ -59,12 +55,13 @@ public class TermCountServiceTest {
 		// Assert
 		HashMap<String, Integer> actualCounts = NlpUtil.extractNoun(post.getContent());
 		HashMap<String, Integer> expectedCounts = new HashMap<>();
-		List<String> wordList = Arrays.asList("World", "test", "post");
-		for (String word : wordList) {
-			expectedCounts.put(word, 1);
-		}
+		expectedCounts.put("World", 1);
+		expectedCounts.put("test", 2);
+		expectedCounts.put("post", 1);
+		int totalTermCount = expectedCounts.size();
+
 		TestUtil.assertMapEquals(expectedCounts, actualCounts);
-		verify(termCountRepository, times(wordList.size())).save(any(TermCount.class));
-		verify(documentCountRepository, times(wordList.size())).save(any(DocumentCount.class));
+		verify(termCountRepository, times(totalTermCount)).save(any(TermCount.class));
+		verify(documentCountRepository, times(totalTermCount)).save(any(DocumentCount.class));
 	}
 }

--- a/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceTest.java
+++ b/keyword-analyzer/src/test/java/com/example/keywordanalyzer/service/TermCountServiceTest.java
@@ -1,0 +1,70 @@
+package com.example.keywordanalyzer.service;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.keywordanalyzer.model.entity.DocumentCount;
+import com.example.keywordanalyzer.model.entity.Post;
+import com.example.keywordanalyzer.model.entity.TermCount;
+import com.example.keywordanalyzer.model.entity.WordCollection;
+import com.example.keywordanalyzer.repository.DocumentCountRepository;
+import com.example.keywordanalyzer.repository.TermCountRepository;
+import com.example.keywordanalyzer.repository.WordCollectionRepository;
+import com.example.keywordanalyzer.util.NlpUtil;
+import com.example.keywordanalyzer.util.TestUtil;
+
+@ExtendWith(MockitoExtension.class)
+public class TermCountServiceTest {
+	@Mock
+	private WordCollection wordCollection;
+	@Mock
+	private TermCountRepository termCountRepository;
+	@Mock
+	private WordCollectionRepository wordCollectionRepository;
+	@Mock
+	private DocumentCountRepository documentCountRepository;
+
+	@InjectMocks
+	private TermCountService service;
+
+	private Post post;
+
+	@BeforeEach
+	void setUp() {
+		Mockito.when(wordCollection.getId()).thenReturn(1L);
+		Mockito.when(wordCollectionRepository.existsById(wordCollection.getId())).thenReturn(true);
+		post = new Post("Hello World! This is test post.", LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+			wordCollection.getId(), 1L);
+	}
+
+	@Test
+	void saveTermCountWithPost() {
+		// Arrange
+
+		// Act
+		service.saveTermCount(post);
+
+		// Assert
+		HashMap<String, Integer> actualCounts = NlpUtil.extractNoun(post.getContent());
+		HashMap<String, Integer> expectedCounts = new HashMap<>();
+		List<String> wordList = Arrays.asList("World", "test", "post");
+		for (String word : wordList) {
+			expectedCounts.put(word, 1);
+		}
+		TestUtil.assertMapEquals(expectedCounts, actualCounts);
+		verify(termCountRepository, times(wordList.size())).save(any(TermCount.class));
+		verify(documentCountRepository, times(wordList.size())).save(any(DocumentCount.class));
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#5 

## 📝작업 내용

문서 별 단어 개수 저장 기능 추가
문서 묶음 별 단어 존재하는 문서 개수 업데이트 기능 추가